### PR TITLE
changed links of the edit page to correct docs,

### DIFF
--- a/apps/portalbase/macros/page/edit/1_edit_macro.py
+++ b/apps/portalbase/macros/page/edit/1_edit_macro.py
@@ -61,12 +61,12 @@ def main(j, args, params, tags, tasklet):
         return params
 
     pagetype = 'md' if path.endswith('.md') else 'wiki'
-    documentation = ("WIKI syntax", "https://gig.gitbooks.io/jumpscale/content/Portal/Wiki/Wiki.html")
+    documentation = ("WIKI syntax", "https://gig.gitbooks.io/jumpscale8/content/Portal/Wiki/Wiki.html")
     if pagetype == 'md':
-        documentation = ("MarkDown syntax", "https://gig.gitbooks.io/jumpscale/content/Portal/Wiki/Wiki%20Syntax%20Markdown.html")
+        documentation = ("MarkDown syntax", "https://gig.gitbooks.io/jumpscale8/content/Portal/Wiki/Wiki%20Syntax%20Markdown.html")
 
     page.addLink("More Info on %s" % documentation[0], "%s" % documentation[1], newtab=True) 
-    page.addLink("Macros Documentation", "https://gig.gitbooks.io/jumpscale/content/Portal/Macros/Macros.html", newtab=True)
+    page.addLink("Macros Documentation", "https://gig.gitbooks.io/jumpscale8/content/Portal/Macros/Macros.html", newtab=True)
     content = j.sal.fs.fileGetContents(path)
 
     page.addMessage('<div class="span12">')

--- a/apps/portalbase/macros/page/edit/1_edit_macro.py
+++ b/apps/portalbase/macros/page/edit/1_edit_macro.py
@@ -61,7 +61,7 @@ def main(j, args, params, tags, tasklet):
         return params
 
     pagetype = 'md' if path.endswith('.md') else 'wiki'
-    documentation = ("WIKI syntax", "https://github.com/Jumpscale/jumpscale_portal/wiki/Wiki-Syntax")
+    documentation = ("WIKI syntax", "https://gig.gitbooks.io/jumpscale/content/Portal/Wiki/Wiki.html")
     if pagetype == 'md':
         documentation = ("MarkDown syntax", "https://gig.gitbooks.io/jumpscale/content/Portal/Wiki/Wiki%20Syntax%20Markdown.html")
 


### PR DESCRIPTION
https://github.com/Jumpscale/jumpscale_portal8/issues/29

the macros link already points to correct location 
the wiki link was changed to point to the intro docs of wiki (this has a todo on it and is empty)https://gig.gitbooks.io/jumpscale/content/Portal/Wiki/Wiki.html