### PR TITLE
Adding github webhook support in portal

### DIFF
--- a/apps/gridportal/base/Cockpit/.macros/wiki/webhook/3_webhook.py
+++ b/apps/gridportal/base/Cockpit/.macros/wiki/webhook/3_webhook.py
@@ -1,0 +1,8 @@
+
+def main(j, args, params, tags, tasklet):
+    key = args.getTag('key')
+    data = j.core.db.hget('webhooks', key)
+    data = j.data.serializer.json.loads(data)
+    args.doc.applyTemplate({'payload': data})
+    params.result = (args.doc, args.doc)
+    return params

--- a/apps/gridportal/base/Cockpit/.macros/wiki/webhooks/3_webhooks.py
+++ b/apps/gridportal/base/Cockpit/.macros/wiki/webhooks/3_webhooks.py
@@ -1,0 +1,12 @@
+
+def main(j, args, params, tags, tasklet):
+    hooks = j.core.db.hgetall('webhooks')
+    out = ['||Oranization/Repo||Event||Time Stamp||']
+    for key, data in hooks.items():
+        data = j.data.serializer.json.loads(data)
+        event, sha1, time = key.decode().split('.')
+        time = j.data.time.epoch2HRDateTime(time)
+        info = {'repo': data['repository']['full_name'], 'event': event, 'time': '[%s|/cockpit/webhook?key=%s]' % (time, key.decode())}
+        out.append('|%(repo)s|%(event)s|%(time)s|' % info)
+    params.result = ('\n'.join(out), args.doc)
+    return params

--- a/apps/gridportal/base/Cockpit/Webhooks/Webhook.wiki
+++ b/apps/gridportal/base/Cockpit/Webhooks/Webhook.wiki
@@ -1,0 +1,15 @@
+@usedefaults
+
+{{timestamp}}
+
+{{webhook key:$$key}}
+
+{% for key, value in payload.items() -%}
+    {% if value is mapping %}
+        {% for k, v in value.items() -%}
+            |*${key}: ${k} *|${v}|
+        {% endfor %}
+    {% else %}
+        |*${key}* | ${value} |
+    {% endif %}
+{% endfor %}

--- a/apps/gridportal/base/Cockpit/Webhooks/Webhooks.wiki
+++ b/apps/gridportal/base/Cockpit/Webhooks/Webhooks.wiki
@@ -1,0 +1,4 @@
+@usedefaults
+
+{{webhooks}}
+

--- a/lib/portal/portal/PortalServer.py
+++ b/lib/portal/portal/PortalServer.py
@@ -730,6 +730,12 @@ class PortalServer:
         elif match == 'render':
             return self.render(environ, start_response)
 
+        elif match == 'webhooks':
+            key = '%s.%s.%s' % (environ.get('HTTP_X_GITHUB_EVENT'), environ.get('HTTP_X_GITHUB_DELIVERY'), j.data.time.epoch)
+            payload = environ['JS_CTX'].params['payload']
+            j.core.db.hset('webhooks', key, payload)
+            return
+
         else:
             path = '/'.join(pathparts)
             ctx.params["path"] = '/'.join(pathparts)


### PR DESCRIPTION
github webhooks can be added on organization level or repo level.
To save webhook events in JSPortal, it should be something like "http://< address >/webhooks"

(see: https://github.com/gig-projects/org_development/issues/11)