### PR TITLE
Implement mandrill webhook

### DIFF
--- a/apps/gridportal/base/system__webhooks/.actor/acl.cfg
+++ b/apps/gridportal/base/system__webhooks/.actor/acl.cfg
@@ -1,0 +1,7 @@
+#rights:
+##R: read
+##W: write/modify
+##S: sync to e.g. local PC
+##A: admin rights
+##*: means all rights
+guest=RW

--- a/apps/gridportal/base/system__webhooks/.actor/main.cfg
+++ b/apps/gridportal/base/system__webhooks/.actor/main.cfg
@@ -1,0 +1,3 @@
+[main]
+id = system__webhooks
+

--- a/apps/gridportal/base/system__webhooks/methodclass/system_webhooks.py
+++ b/apps/gridportal/base/system__webhooks/methodclass/system_webhooks.py
@@ -1,0 +1,52 @@
+from JumpScale import j
+import time
+
+
+class system_webhooks(j.tools.code.classGetBase()):
+
+    """
+    """
+
+    def __init__(self):
+        pass
+
+        self._te = {}
+        self.actorname = "webhooks"
+        self.appname = "system"
+        # system_atyourservice_osis.__init__(self)
+
+    def github(self, payload, ctx, **kwargs):
+        """
+        param:payload 
+        result json
+        """
+        environ = ctx.env
+        key = '%s.%s.%s' % (environ.get('HTTP_X_GITHUB_EVENT'), environ.get('HTTP_X_GITHUB_DELIVERY'), j.data.time.epoch)
+        j.core.db.hset('webhooks', key, payload)
+        return True
+
+    def mandrill(self, mandrill_events, **kwargs):
+        """
+        param:mandrill_events 
+        result json
+        """
+        messages = j.data.serializer.json.loads(mandrill_events)
+        dir = j.sal.fs.joinPaths(j.dirs.varDir, 'email')
+
+        for message in messages:
+            ts = time.gmtime(message['ts'])
+            #we generate a random guid to avoid ts conflict if 2 or more
+            #messages are received with the same timestamp. We also don't
+            #only use the guid, so we don't lose the time information
+            key = "%s-%s" (message['ts'], j.data.idgenerator.generateGUID())
+            path = j.sal.fs.joinPaths(dir, ts.tm_year, ts.tm_mon, ts.tm_mday)
+            j.sal.fs.createDir(path)
+            msg = message['msg']
+            j.sal.fs.writeFile(j.sal.fs.joinPaths(path, key), j.data.serializer.json.dumps(msg))
+
+            #set the email hset, and push key to queue, but we keep only meta information
+            for k in ('raw_msg', 'headers', 'text', 'html', 'attachments', 'images', 'spam_report'):
+                msg.pop(k, None)
+
+            j.core.db.hset('mails', key, j.data.serializer.json.dumps(msg))
+            j.core.db.rpush('mails.queue', key)

--- a/apps/gridportal/base/system__webhooks/specs/actor.spec
+++ b/apps/gridportal/base/system__webhooks/specs/actor.spec
@@ -1,0 +1,14 @@
+[actor] @dbtype:mem,fs
+    """
+    """    
+    method:mandrill @noauth
+        """
+        """
+        var:mandrill_events str,,
+        result:json
+
+    method:github @noauth
+        """
+        """
+        var:payload str,,
+        result:json

--- a/lib/portal/portal/PageProcessor.py
+++ b/lib/portal/portal/PageProcessor.py
@@ -33,7 +33,7 @@ class PageProcessor():
     def sendpage(self, page, start_response):
         contenttype = "text/html"
         start_response('200 OK', [('Content-Type', contenttype), ])
-        return [page.getContent().encode('utf-8')]
+        return [page.getContent()]
 
     def getDoc(self, space, name, ctx, params={}):
         session = ctx.env['beaker.session']
@@ -151,7 +151,7 @@ class PageProcessor():
             page = self.getpage()
             page.addCodeBlock(content, template, edit=True)
             start_response('200 OK', [('Content-Type', contenttype), ])
-            return [str(page).encode('utf-8')]
+            return [str(page)]
 
         def processHtml(contenttype, path, start_response, ctx, space):
             content = j.tools.path.get(path).text()
@@ -176,7 +176,7 @@ class PageProcessor():
                     content = content.replace(match.founditem, page.body)
 
             start_response('200 OK', [('Content-Type', "text/html"), ])
-            return [content.encode('utf-8')]
+            return [content]
 
         def removePrefixes(path):
             path = path.replace("\\", "/")
@@ -234,7 +234,7 @@ class PageProcessor():
                 print("error")
                 headers = [('Content-Type', contenttype), ]
                 start_response("404 Not found", headers)
-                return [("path %s not found" % path).encode('utf-8')]
+                return [("path %s not found" % path)]
 
         size = pathfull.getsize()
 
@@ -262,7 +262,7 @@ class PageProcessor():
         start_response(status, headers)
 
         if content != "":
-            return [content.encode('utf-8')]
+            return [content]
         else:
             return send_file(pathfull, size)
 
@@ -284,7 +284,7 @@ class PageProcessor():
             response = j.data.serializer.serializers.getSerializerType('j').dumps(response)
         else:
             response = response.get('content')
-        return [response.encode('utf-8')]
+        return [response]
 
     def process_proxy(self, ctx, proxy):
         path = ctx.env['PATH_INFO']

--- a/lib/portal/portal/exceptions.py
+++ b/lib/portal/portal/exceptions.py
@@ -1,3 +1,4 @@
+from JumpScale import j
 import http.client
 
 codemapping = http.client.responses.copy()


### PR DESCRIPTION
I totally don't like hardcoding the route and the handler in
the portal router itself, This should be possible to implement
in an APP that runs in the portal. This doesn't look right at all

Secondly, the hook will just dump the event data into file and
push the email key to redis for further processing